### PR TITLE
Configurable config loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .build
 Config-Onion-*
 
+.includepath
+*.project

--- a/Changes
+++ b/Changes
@@ -1,3 +1,6 @@
+1.005   2016-01-17
+- Allow passing parameters to Config::Any
+
 1.004   2014-05-09
 - Changed prefix_key from a global setting to a per-instance property
 

--- a/README.mkdn
+++ b/README.mkdn
@@ -3,9 +3,9 @@
     my $cfg = Config::Onion->new;
     my $cfg = Config::Onion->set_default(db => {name => 'foo', password => 'bar'});
     my $cfg = Config::Onion->load('/etc/myapp', './myapp');
-    my $cfg = Config::Onion->load('/etc/myapp', './myapp', {});
+    my $cfg = Config::Onion->load('/etc/myapp', './myapp', {use_ext => 1, filter => \&filter});
     my $cfg = Config::Onion->load_glob('./plugins/*');
-    my $cfg = Config::Onion->load_glob('./plugins/*', {filter => \&filter});
+    my $cfg = Config::Onion->load_glob('./plugins/*', {force_plugins => ['Config::Any::YAML']});
 
     $cfg->set_default(font => 'Comic Sans');
     $cfg->load('config');

--- a/README.mkdn
+++ b/README.mkdn
@@ -3,7 +3,9 @@
     my $cfg = Config::Onion->new;
     my $cfg = Config::Onion->set_default(db => {name => 'foo', password => 'bar'});
     my $cfg = Config::Onion->load('/etc/myapp', './myapp');
+    my $cfg = Config::Onion->load('/etc/myapp', './myapp', {});
     my $cfg = Config::Onion->load_glob('./plugins/*');
+    my $cfg = Config::Onion->load_glob('./plugins/*', {filter => \&filter});
 
     $cfg->set_default(font => 'Comic Sans');
     $cfg->load('config');
@@ -67,6 +69,7 @@ The design intent for each layer is:
     Returns a new, empty configuration object.
 
     ## load(@file\_stems)
+    ## load(@file\_stems, {...})
 
     Loads files matching the given stems using `Config::Any->load_stems` into
     the Main layer.  Also concatenates ".local" to each stem and loads matching
@@ -75,12 +78,23 @@ The design intent for each layer is:
     extensions supported by `Config::Any` are recognized along with their
     corresponding formats.
 
+    An optional hash ref final argument can be provided to override the default
+    option `use_ext => 1` passed to `Config::Any`.  All options supported by `Config::Any`
+    are supported except flatten_to_hash.  See `Config::Any->load_files` documentation
+    for available options.
+
     ## load\_glob(@globs)
+    ## load\_glob(@globs, {...})
 
     Uses the Perl `glob` function to expand each parameter into a list of
     filenames and loads each file using `Config::Any`.  Files whose names contain
     the string ".local." are loaded into the Local layer.  All other files are
     loaded into the Main layer.
+
+    An optional hash ref final argument can be provided to override the default
+    option `use_ext => 1` passed to `Config::Any`.  All options supported by `Config::Any`
+    are supported except flatten_to_hash.  See `Config::Any->load_files` documentation
+    for available options.
 
     ## set\_default(\[\\%settings,...,\] %settings)
 

--- a/t/02-load.t
+++ b/t/02-load.t
@@ -72,5 +72,11 @@ my $conf_dir = $FindBin::Bin . '/conf';
   ok(!defined $cfg->get->{deep}, 'non-prefix keys cleared from config');
 }
 
+# pass parameter to Config::Any, overrides use_ext
+{
+  my $cfg = Config::Onion->load_glob("$conf_dir/basic*", {force_plugins => ['Config::Any::YAML']});
+  is($cfg->get->{joker}, 'one', 'use_ext was not used');
+}
+
 done_testing;
 

--- a/t/conf/basic2.zzz
+++ b/t/conf/basic2.zzz
@@ -1,0 +1,5 @@
+
+foo: baz
+joker: one
+xyzzy: plug
+


### PR DESCRIPTION
I believe this pull request addresses Issue #3 .  It allows you to override all of the parameters passed to Config::Any with the exception of flatten_to_hash which I believe would break Config::Onion.  To safeguard against this, I added a check to see if flatten_to_hash is passed in and remove it before passing to Config::Any.