### PR TITLE
fix test so that it runs (PRC)

### DIFF
--- a/t/02-load.t
+++ b/t/02-load.t
@@ -40,7 +40,7 @@ my $conf_dir = $FindBin::Bin . '/conf';
 
 # load files by glob match
 {
-  my $cfg = Config::Onion->load_glob("$conf_dir/*");
+  my $cfg = Config::Onion->load_glob("$conf_dir/*", {use_ext => 1, force_plugins => ['Config::Any::YAML']});
   ok(defined $cfg->get->{joker}, 'load multiple configs');
   is($cfg->get->{joker}, 'wild',
     'globbed load gives precedence to later files');


### PR DESCRIPTION
added force_plugins to force the use of yaml plugin, without an update
to config::any, it seems that use_ext will be set regardless to what the
user wants.