### PR TITLE
fix how use_ext is handled for load_glob

### DIFF
--- a/lib/Config/Onion.pm
+++ b/lib/Config/Onion.pm
@@ -80,9 +80,18 @@ sub load_glob {
     delete $ca_opts->{flatten_to_hash} if exists $ca_opts->{flatten_to_hash};
   }
 
+  # if use_ext is on, we need to query Config::Any to see what extensions are allowed
+  my $ext_re = '';
+  if ($ca_opts->{use_ext}) {
+    my @exts = Config::Any->extensions();
+    $ext_re = '\.' . (shift @exts) . '$';
+    $ext_re .= "|\\.$_\$" foreach @exts;
+  }
+
   my (@main_files, @local_files);
   for my $globspec (@_) {
     for (glob $globspec) {
+      next if $ca_opts->{use_ext} && !/$ext_re/;
       if (/\.local\./) { push @local_files, $_ }
       else             { push @main_files,  $_ }
     }

--- a/t/02-load.t
+++ b/t/02-load.t
@@ -40,7 +40,7 @@ my $conf_dir = $FindBin::Bin . '/conf';
 
 # load files by glob match
 {
-  my $cfg = Config::Onion->load_glob("$conf_dir/*", {use_ext => 1, force_plugins => ['Config::Any::YAML']});
+  my $cfg = Config::Onion->load_glob("$conf_dir/*");
   ok(defined $cfg->get->{joker}, 'load multiple configs');
   is($cfg->get->{joker}, 'wild',
     'globbed load gives precedence to later files');


### PR DESCRIPTION
query Config::Any for list of allowed extensions, build regex to filter
what is returned from glob.